### PR TITLE
Add GitHub Actions workflow for PWA deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy PWA to GitHub Pages
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Export PWA
+        run: npx expo export --platform web
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A brief description of what this project does and who it's for.
 
+## Deployment
+
+This repository includes a GitHub Actions workflow to automatically deploy the PWA to GitHub Pages on every push to `main` or `master`.
+
+To enable this:
+1. Go to your repository settings on GitHub.
+2. Navigate to **Pages** in the left sidebar.
+3. Under **Build and deployment > Source**, select **GitHub Actions**.
+
+The PWA will be built using `npx expo export` and deployed to the GitHub Pages environment.
+
 ## Getting Started
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.


### PR DESCRIPTION
- Create `.github/workflows/deploy.yml` with modern build and deploy steps for Expo PWA.
- Update `README.md` with instructions on how to enable GitHub Actions for GitHub Pages in the repository settings.
- Ensure the workflow is generic and can be adapted to other projects.